### PR TITLE
chore: podłącz repo pod centralne presety Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>dudziakm/dep-automation:js"]
+}


### PR DESCRIPTION
Dodaje `renovate.json` wskazujący na warstwę `js` w [dudziakm/dep-automation](https://github.com/dudziakm/dep-automation).

Config musi istnieć **przed** instalacją aplikacji Renovate — inaczej bot zrobi onboarding z gołym `config:recommended` i ominie tę politykę.

Na tym etapie `automerge` jest wyłączony: najpierw chcemy zmierzyć, ile i jakich PR-ów bot generuje.