### PR TITLE
Add a light verify gate for dependency updates

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,233 @@
+name: verify
+
+# Lekka bramka dla aktualizacji zaleznosci: instalacja, typecheck i build.
+# Swiadomie NIE uruchamia E2E. Zestawy Playwrighta i Cypressa w tych repo
+# celuja w zewnetrzne serwisy, ktore znikaja, przekierowuja albo blokuja ruch
+# z centrow danych — jako bramka daja szum, nie dowod. Tu chodzi o sygnal,
+# ktory jest zielony wtedy i tylko wtedy, gdy podbicie wersji niczego nie zepsulo.
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Opt-in smoke start for service repos: set VERIFY_SMOKE to 'true' in this
+# workflow on repositories that expose a real start script. Default stays off so
+# install-only / E2E harness repos are not started as servers.
+env:
+  VERIFY_SMOKE: 'false'
+
+concurrency:
+  group: verify-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      dirs: ${{ steps.find.outputs.dirs }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: find
+        name: Znajdz katalogi projektow
+        run: |
+          set -euo pipefail
+          if [ -f package.json ]; then
+            dirs='["."]'
+          else
+            dirs=$(find . -maxdepth 4 -name package.json \
+                     -not -path '*/node_modules/*' \
+                     -not -path '*/.next/*' \
+                     -not -path '*/dist/*' \
+                     -not -path '*/build/*' \
+                     -printf '%h\n' | sort -u | jq -R . | jq -sc .)
+          fi
+          echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
+          echo "Katalogi do sprawdzenia: $dirs"
+
+  verify:
+    needs: discover
+    if: needs.discover.outputs.dirs != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: ${{ fromJSON(needs.discover.outputs.dirs) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.dir }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: pm
+        name: Wykryj menedzera pakietow
+        run: |
+          set -euo pipefail
+          if   [ -f pnpm-lock.yaml ]; then mgr=pnpm
+          elif [ -f yarn.lock ];      then mgr=yarn
+          else                             mgr=npm
+          fi
+          echo "mgr=$mgr" >> "$GITHUB_OUTPUT"
+          echo "Menedzer: $mgr"
+
+      - uses: pnpm/action-setup@v4
+        if: steps.pm.outputs.mgr == 'pnpm'
+        with:
+          version: 10
+
+      # Bez 'cache:' celowo — setup-node przerywa twardo, gdy nie znajdzie
+      # lockfile'a, a czesc repo go nie ma. Bramka ma byc odporna, nie szybka.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Instalacja
+        run: |
+          set -euo pipefail
+          case "${{ steps.pm.outputs.mgr }}" in
+            pnpm) pnpm install --frozen-lockfile ;;
+            yarn) yarn install --immutable ;;
+            npm)
+              if [ -f package-lock.json ]; then
+                npm ci
+              else
+                echo "Brak package-lock.json — instaluje bez zamrozenia."
+                npm install --no-audit --no-fund
+              fi
+              ;;
+          esac
+
+      # Wlasny skrypt repo ma pierwszenstwo przed golym tsc. Frameworki generuja
+      # typy dopiero w swoim kroku sync (Astro, Next, SvelteKit), wiec samo
+      # 'tsc --noEmit' zglasza brakujace moduly wirtualne i daje falszywa czerwien.
+      - name: Typecheck
+        run: |
+          set -euo pipefail
+          script=$(node -e "const s=require('./package.json').scripts||{};process.stdout.write(s.typecheck?'typecheck':(s['type-check']?'type-check':''))")
+          if [ -n "$script" ]; then
+            echo "Uzywam skryptu repo: $script"
+            case "${{ steps.pm.outputs.mgr }}" in
+              pnpm) pnpm run "$script" ;;
+              yarn) yarn run "$script" ;;
+              npm)  npm run "$script" ;;
+            esac
+            exit 0
+          fi
+          if [ ! -f tsconfig.json ]; then
+            echo "Brak skryptu typecheck i brak tsconfig.json — pomijam."; exit 0
+          fi
+          if ! node -e "const p=require('./package.json');const d={...p.dependencies,...p.devDependencies};process.exit(d.typescript?0:1)"; then
+            echo "typescript nie jest zalezoscia repo — pomijam, zeby nie sciagac losowej wersji."; exit 0
+          fi
+          npx --no-install tsc --noEmit
+
+      - name: Build
+        run: |
+          set -euo pipefail
+          if ! node -e "const p=require('./package.json');process.exit(p.scripts&&p.scripts.build?0:1)"; then
+            echo "Brak skryptu build — pomijam."; exit 0
+          fi
+          case "${{ steps.pm.outputs.mgr }}" in
+            pnpm) pnpm run build ;;
+            yarn) yarn run build ;;
+            npm)  npm run build ;;
+          esac
+
+      # Opt-in: set VERIFY_SMOKE=true (workflow env or repo variable) on services
+      # with a start script. Distinguishes missing credentials (soft pass) from
+      # dependency crashes (fail).
+      - name: Smoke start
+        if: env.VERIFY_SMOKE == 'true'
+        run: |
+          set -euo pipefail
+          if ! node -e "const s=require('./package.json').scripts||{};process.exit(s.start?0:1)"; then
+            echo "Brak skryptu start — pomijam smoke."; exit 0
+          fi
+          log="$(mktemp)"
+          case "${{ steps.pm.outputs.mgr }}" in
+            pnpm) pnpm run start >"$log" 2>&1 & ;;
+            yarn) yarn run start >"$log" 2>&1 & ;;
+            npm)  npm run start >"$log" 2>&1 & ;;
+          esac
+          pid=$!
+          # Give the process a few seconds to boot or crash.
+          for i in 1 2 3 4 5 6 7 8; do
+            if ! kill -0 "$pid" 2>/dev/null; then
+              wait "$pid" || true
+              echo "----- smoke stdout/stderr -----"
+              cat "$log"
+              if grep -Eiq 'API[_-]?KEY|api key|OPENAI|ANTHROPIC|SUPABASE|supabaseKey is required|missing.*(env|key|credential)|not set|ECONNREFUSED.*(54321|5432)' "$log"; then
+                echo "Smoke: process exited for missing credentials/config — treating as soft pass."
+                exit 0
+              fi
+              if grep -Eiq 'Cannot find module|ERR_MODULE_NOT_FOUND|MODULE_NOT_FOUND|SyntaxError|TypeError:|Error: Cannot' "$log"; then
+                echo "Smoke: dependency/runtime crash — failing the gate."
+                exit 1
+              fi
+              echo "Smoke: process exited before becoming ready without a clear credentials signal — failing."
+              exit 1
+            fi
+            if grep -Eiq 'listening|started|ready|localhost:[0-9]|Local:|Network:' "$log"; then
+              echo "Smoke: server looks ready."
+              kill "$pid" 2>/dev/null || true
+              wait "$pid" 2>/dev/null || true
+              echo "----- smoke stdout/stderr (truncated) -----"
+              tail -n 40 "$log"
+              exit 0
+            fi
+            sleep 1
+          done
+          # Still alive after the window — good enough for a smoke check.
+          echo "Smoke: process still running after boot window — OK."
+          kill "$pid" 2>/dev/null || true
+          wait "$pid" 2>/dev/null || true
+          tail -n 40 "$log"
+
+      # Bramka, ktora po cichu pomija typecheck i build, swieci na zielono po samej
+      # instalacji. To wciaz realny sygnal (zla wersja, rozjechany lockfile, konflikt
+      # peer albo override), ale duzo slabszy niz sie wydaje. Wypisujemy wprost, co
+      # faktycznie zostalo sprawdzone, zeby nikt nie budowal na tym falszywej pewnosci.
+      - name: Co ta bramka faktycznie sprawdzila
+        if: always()
+        run: |
+          set -euo pipefail
+          ts=nie
+          if node -e "const s=require('./package.json').scripts||{};process.exit(s.typecheck||s['type-check']?0:1)"; then
+            ts="tak (skrypt repo)"
+          elif [ -f tsconfig.json ] && node -e "const p=require('./package.json');const d={...p.dependencies,...p.devDependencies};process.exit(d.typescript?0:1)"; then
+            ts="tak (tsc --noEmit)"
+          fi
+          bd=nie
+          if node -e "const p=require('./package.json');process.exit(p.scripts&&p.scripts.build?0:1)"; then
+            bd=tak
+          fi
+          sm=nie
+          if [ "${VERIFY_SMOKE:-false}" = "true" ] && node -e "const s=require('./package.json').scripts||{};process.exit(s.start?0:1)"; then
+            sm=tak
+          fi
+          {
+            echo "### Bramka verify — \`${{ matrix.dir }}\`"
+            echo ""
+            echo "| Etap | Uruchomiony |"
+            echo "|---|---|"
+            echo "| instalacja zaleznosci | tak |"
+            echo "| typecheck (\`tsc --noEmit\`) | $ts |"
+            echo "| build | $bd |"
+            echo "| smoke start | $sm |"
+            if [ "$ts" = nie ] && [ "$bd" = nie ]; then
+              echo ""
+              echo "> **Uwaga:** w tym katalogu bramka sprawdza wylacznie instalacje."
+              echo "> Nie traktuj zielonego wyniku jako dowodu, ze aktualizacja niczego nie zepsula."
+            fi
+            if [ "$ts" = "tak (tsc --noEmit)" ]; then
+              echo ""
+              echo "> \`tsc --noEmit\` przy \`skipLibCheck: true\` (typowe ustawienie) nie wykrywa"
+              echo "> wiekszosci regresji w typach samych zaleznosci — tylko te, ktore wychodza"
+              echo "> na powierzchni w kodzie repo."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds `.github/workflows/verify.yml`: lockfile install, typecheck when TypeScript is present, and build when a build script exists. No E2E.