### PR TITLE
Post a verify commit status for private-repo automerge

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 # Opt-in smoke start for service repos: set VERIFY_SMOKE to 'true' in this
 # workflow on repositories that expose a real start script. Default stays off so
@@ -231,3 +232,33 @@ jobs:
               echo "> na powierzchni w kodzie repo."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # Private GitHub Free repos expose this workflow as check-runs. A
+  # fine-grained PAT cannot call the Checks API, so Renovate sees combined
+  # status pending / total_count: 0 unless a commit status named `verify`
+  # exists. GITHUB_TOKEN can create statuses; keep existing jobs unchanged.
+  post-verify-status:
+    needs: [discover, verify]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post verify commit status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const discover = '${{ needs.discover.result }}';
+            const verify = '${{ needs.verify.result }}';
+            const ok =
+              discover === 'success' &&
+              (verify === 'success' || verify === 'skipped');
+            const sha =
+              context.payload.pull_request?.head?.sha || context.sha;
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: ok ? 'success' : 'failure',
+              context: 'verify',
+              description: ok ? 'Verify gate passed' : 'Verify gate failed',
+              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });


### PR DESCRIPTION
## Summary
- Add a `post-verify-status` job to the existing verify workflow so it posts a commit status named `verify` (success/failure).
- Private GitHub Free repos expose verify as check-runs; the Renovate PAT cannot call the Checks API, so combined status stays pending unless a commit status exists. `GITHUB_TOKEN` can create statuses.
- Existing discover/verify jobs are unchanged.

## Test plan
- [ ] Verify workflow is green on this PR
- [ ] Combined commit status includes context `verify`
